### PR TITLE
Fix issue #2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -681,7 +681,7 @@ rule jaeger:
     shell:
         """
 parallel --jobs {threads} --retry-failed --halt='now,fail=1'\
- Jaeger -p --workers 1 -i {{}} -o "{params.output_dir}{{/.}}" --overwrite\
+ jaeger run -p --workers 1 -i {{}} -o "{params.output_dir}{{/.}}" --overwrite\
  > {log} 2>&1 ::: {input.batch}/*.fa
 
 touch {output}

--- a/envs/jaeger.yaml
+++ b/envs/jaeger.yaml
@@ -1,7 +1,7 @@
 name: jaeger
 
 dependencies:
- - jaeger-bio=1.1.26
+ - jaeger-bio=1.1.30
 
 channels:
  - conda-forge


### PR DESCRIPTION
By updating to the next version, there is no longer a line checking for file name extensions. This new version also has slightly different commands (lowercase 'jaeger run' instaed of 'Jaeger').