### PR TITLE
Cleanup

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -904,24 +904,7 @@ rule create_spacepharer_table:
     threads: 1
     log:
         "log/create_spacepharer_table.txt"
-    shell:
-        """
-        echo -e "sample_accession\tphage_accession\tp_best_hit\tspacer_start\tspacer_end\tphage_start\tphage_end\t5_3_PAM\t3_5_PAM\tLength\tGC_content\ttaxonomy\tcompleteness\thost\tlifestyle" > {output.phage}
-        while read line; do
-            ID=$(echo $line | cut -f 2)
-            metadata_match=$(grep -w "$ID" {input.meta_phage}/merged_metadata.tsv | cut -f 2-7)
-            echo -e "$line\t$metadata_match" >> {output.phage}
-        done < {input.phage}
-        
-        echo "starting plasmid"
-        echo -e "sample_accession\tphage_accession\tp_best_hit\tspacer_start\tspacer_end\tphage_start\tphage_end\t5_3_PAM\t3_5_PAM\ttaxonomy" > {output.plasmid}
-        while read line; do
-            ID=$(echo $line | cut -f 2)
-            nuccore_match=$(grep -w "$ID" {input.meta_plasmid}/nuccore.csv | cut -f 13 -d ",")
-            taxonomy_match=$(grep -w "^$nuccore_match" {input.meta_plasmid}/taxonomy.csv | cut -f 3 -d ",")
-            echo -e "$line\t$taxonomy_match" >> {output.plasmid}
-        done < {input.plasmid}
-        """
+    script: bin/create_spacepharer_table.sh
 
 rule kma_indexing:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -908,18 +908,18 @@ rule create_spacepharer_table:
         """
         echo -e "sample_accession\tphage_accession\tp_best_hit\tspacer_start\tspacer_end\tphage_start\tphage_end\t5_3_PAM\t3_5_PAM\tLength\tGC_content\ttaxonomy\tcompleteness\thost\tlifestyle" > {output.phage}
         while read line; do
-            ID=$(echo $line | cut -f 2 -d " ")
+            ID=$(echo $line | cut -f 2)
             metadata_match=$(grep -w "$ID" {input.meta_phage}/merged_metadata.tsv | cut -f 2-7)
-            echo -e "$line $metadata_match" >> {output.phage}
+            echo -e "$line\t$metadata_match" >> {output.phage}
         done < {input.phage}
         
         echo "starting plasmid"
         echo -e "sample_accession\tphage_accession\tp_best_hit\tspacer_start\tspacer_end\tphage_start\tphage_end\t5_3_PAM\t3_5_PAM\ttaxonomy" > {output.plasmid}
         while read line; do
-            ID=$(echo $line | cut -f 2 -d " ")
+            ID=$(echo $line | cut -f 2)
             nuccore_match=$(grep -w "$ID" {input.meta_plasmid}/nuccore.csv | cut -f 13 -d ",")
             taxonomy_match=$(grep -w "^$nuccore_match" {input.meta_plasmid}/taxonomy.csv | cut -f 3 -d ",")
-            echo -e "$line $taxonomy_match" >> {output.plasmid}
+            echo -e "$line\t$taxonomy_match" >> {output.plasmid}
         done < {input.plasmid}
         """
 

--- a/bin/create_spacepharer_table.sh
+++ b/bin/create_spacepharer_table.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+## this script uses the output from the two spacepharer matches created from the spacepharer rules. This script assumes that Phagescope and PLSDB are the used databases.
+## Overall the script takes every match and extracts the ID which is directly taking from the database and then tries to match this back to the metadata and attach this to the match.
+
+#spacepharer does not include its own column names and expected metadata column names are also manually added
+echo -e "sample_accession\tphage_accession\tp_best_hit\tspacer_start\tspacer_end\tphage_start\tphage_end\t5_3_PAM\t3_5_PAM\tLength\tGC_content\ttaxonomy\tcompleteness\thost\tlifestyle" > ${snakemake_output[phage]}
+while read line; do
+    ID=$(echo $line | cut -f 2)
+    metadata_match=$(grep -w "$ID" ${snakemake_input[meta_phage]}/merged_metadata.tsv | cut -f 2-7)
+    echo -e "$line\t$metadata_match" >> ${snakemake_output[phage]}
+done < ${snakemake_input[phage]}
+
+echo "starting plasmid"
+echo -e "sample_accession\tphage_accession\tp_best_hit\tspacer_start\tspacer_end\tphage_start\tphage_end\t5_3_PAM\t3_5_PAM\ttaxonomy" > ${snakemake_output[plasmid]}
+while read line; do
+    ID=$(echo $line | cut -f 2)
+    #PLSDB uses a metadata system where there are many different files for differing purposes. taxonomy.csv uses a different ID so the taxonomy ID needs to be collected from nuccore and then matched to taxonomy
+    nuccore_match=$(grep -w "$ID" ${snakemake_input[meta_plasmid]}/nuccore.csv | cut -f 13 -d ",")
+    taxonomy_match=$(grep -w "^$nuccore_match" ${snakemake_input[meta_plasmid]}/taxonomy.csv | cut -f 3 -d ",")
+    echo -e "$line\t$taxonomy_match" >> ${snakemake_output[plasmid]}
+done < ${snakemake_input[plasmid]}


### PR DESCRIPTION
i've done some minor cleanup for at least create spacepharer table.

Other scripts in snakemake seem short enough to not need a separate script. The other two of note are the kma scripts and merging CRISPRidentify and CCTyper. However, i think these two need not still be included in CRISPRscape because i believe we are moving over to a different genome comparison tool and merging CRISPRidentify and CCTyper has currently many more issues that need to be considered before we can reliably merge them together. (this includes things such as non-overlapping arrays between the two)